### PR TITLE
Add GitHub Action to import wiki Markdown into `wiki-src` and record import status

### DIFF
--- a/.github/workflows/import-wiki.yml
+++ b/.github/workflows/import-wiki.yml
@@ -1,0 +1,43 @@
+name: Import Wiki Markdown
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  import-wiki:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Clone wiki repository
+        env:
+          WIKI_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git
+        run: |
+          git clone "$WIKI_URL" wiki-repo
+
+      - name: Copy wiki markdown into wiki-src
+        run: |
+          mkdir -p wiki-src
+          find wiki-repo -type f -name '*.md' -exec cp {} wiki-src/ \;
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+
+          git add wiki-src
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit after staging."
+            exit 0
+          fi
+
+          git commit -m "Import wiki markdown into wiki-src"
+          git push origin HEAD:main

--- a/wiki-src/IMPORT_STATUS.md
+++ b/wiki-src/IMPORT_STATUS.md
@@ -1,0 +1,19 @@
+# Wiki import status
+
+Attempted to clone the wiki repository:
+
+- `https://github.com/ErnestMatskevich/kb-knowledge.wiki.git`
+
+Result in this environment:
+
+- `CONNECT tunnel failed, response 403`
+
+Because outbound access to GitHub is blocked in this runtime, `.md` files from the wiki could not be fetched automatically.
+
+To complete the import in an environment with GitHub access, run:
+
+```bash
+git clone https://github.com/ErnestMatskevich/kb-knowledge.wiki.git /tmp/kb-knowledge.wiki
+mkdir -p wiki-src
+find /tmp/kb-knowledge.wiki -type f -name '*.md' -exec cp --parents {} wiki-src/ \;
+```


### PR DESCRIPTION
### Motivation

- Provide an automated, on-demand GitHub Actions workflow to import `.md` pages from the repository wiki into a `wiki-src` directory so wiki content can be tracked and built with repository assets. 

### Description

- Add `.github/workflows/import-wiki.yml` which is triggered by `workflow_dispatch`, checks out the repo, clones the wiki via an access token, copies `*.md` files into `wiki-src`, and commits and pushes changes only if there are staged modifications. 
- The workflow uses `actions/checkout@v4`, sets `permissions.contents: write`, clones the wiki with the `GITHUB_TOKEN`, and stages `wiki-src` before conditionally committing. 
- Add `wiki-src/IMPORT_STATUS.md` to record the result of an attempted import in this environment and provide manual `git clone` and `find` commands to complete the import where outbound GitHub access is available. 

### Testing

- An automated attempt to clone the wiki in this environment was recorded and failed with `CONNECT tunnel failed, response 403`, which is documented in `wiki-src/IMPORT_STATUS.md` and caused the import step to not complete. 
- No additional automated tests were run as part of this change; the workflow can be triggered manually via the Actions UI to validate behavior in an environment with outbound GitHub access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a24cc2b66483289a618ec6551da25d)