### PR TITLE
Add workflows to import and sync repository Wiki from wiki-src

### DIFF
--- a/.github/workflows/import-wiki.yml
+++ b/.github/workflows/import-wiki.yml
@@ -1,0 +1,43 @@
+name: Import Wiki Markdown
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  import-wiki:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Clone wiki repository
+        env:
+          WIKI_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git
+        run: |
+          git clone "$WIKI_URL" wiki-repo
+
+      - name: Copy wiki markdown into wiki-src
+        run: |
+          mkdir -p wiki-src
+          find wiki-repo -type f -name '*.md' -exec cp {} wiki-src/ \;
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+
+          git add wiki-src
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit after staging."
+            exit 0
+          fi
+
+          git commit -m "Import wiki markdown into wiki-src"
+          git push origin HEAD:main

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,64 @@
+name: Sync Wiki from wiki-src
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'wiki-src/**/*.md'
+
+permissions:
+  contents: read
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect added/modified wiki-src markdown files
+        id: changes
+        run: |
+          CHANGED_FILES=$(git diff --name-status "${{ github.event.before }}" "${{ github.sha }}" | awk '$1 ~ /^(A|M)$/ && $2 ~ /^wiki-src\/.*\.md$/ {print $2}')
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No added/modified wiki-src markdown files."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changed files:"
+            echo "$CHANGED_FILES"
+          fi
+
+      - name: Clone wiki repository
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          WIKI_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git
+        run: |
+          git clone "$WIKI_URL" wiki-repo
+
+      - name: Copy markdown from wiki-src into wiki repository
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          find wiki-src -type f -name '*.md' -exec cp {} wiki-repo/ \;
+
+      - name: Commit and push wiki changes
+        if: steps.changes.outputs.has_changes == 'true'
+        working-directory: wiki-repo
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+
+          git add .
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git commit -m "Sync wiki from wiki-src"
+          git push origin HEAD


### PR DESCRIPTION
### Motivation

- Automate importing markdown pages from the repository wiki into a `wiki-src` folder and keep the GitHub Wiki in sync with changes under `wiki-src` to simplify documentation updates.

### Description

- Add `/.github/workflows/import-wiki.yml` which provides a `workflow_dispatch` to clone the repository wiki, copy `.md` files into `wiki-src`, and commit them back to `main` if there are changes.  
- Add `/.github/workflows/wiki-sync.yml` which triggers on `push` to `main` for changes in `wiki-src/**/*.md`, detects added/modified files, clones the repo wiki, copies markdown into the wiki repo, and commits/pushes when changes are present.  
- Both workflows use `actions/checkout@v4`, set minimal `contents` permissions, configure `git` user info, and include guards that exit when there is nothing to commit.

### Testing

- No automated tests were run for these workflow files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a24cc2b66483289a618ec6551da25d)