### PR TITLE
Add GitHub Actions to import/sync wiki and add Russian guidance doc

### DIFF
--- a/.github/workflows/import-wiki.yml
+++ b/.github/workflows/import-wiki.yml
@@ -1,0 +1,43 @@
+name: Import Wiki Markdown
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  import-wiki:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Clone wiki repository
+        env:
+          WIKI_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git
+        run: |
+          git clone "$WIKI_URL" wiki-repo
+
+      - name: Copy wiki markdown into wiki-src
+        run: |
+          mkdir -p wiki-src
+          find wiki-repo -type f -name '*.md' -exec cp {} wiki-src/ \;
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+
+          git add wiki-src
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit after staging."
+            exit 0
+          fi
+
+          git commit -m "Import wiki markdown into wiki-src"
+          git push origin HEAD:main

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,64 @@
+name: Sync Wiki from wiki-src
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'wiki-src/**/*.md'
+
+permissions:
+  contents: read
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect added/modified wiki-src markdown files
+        id: changes
+        run: |
+          CHANGED_FILES=$(git diff --name-status "${{ github.event.before }}" "${{ github.sha }}" | awk '$1 ~ /^(A|M)$/ && $2 ~ /^wiki-src\/.*\.md$/ {print $2}')
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No added/modified wiki-src markdown files."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changed files:"
+            echo "$CHANGED_FILES"
+          fi
+
+      - name: Clone wiki repository
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          WIKI_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git
+        run: |
+          git clone "$WIKI_URL" wiki-repo
+
+      - name: Copy markdown from wiki-src into wiki repository
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          find wiki-src -type f -name '*.md' -exec cp {} wiki-repo/ \;
+
+      - name: Commit and push wiki changes
+        if: steps.changes.outputs.has_changes == 'true'
+        working-directory: wiki-repo
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+
+          git add .
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git commit -m "Sync wiki from wiki-src"
+          git push origin HEAD

--- a/wiki-src/Не удаётся получить доступ к API.md
+++ b/wiki-src/Не удаётся получить доступ к API.md
@@ -1,0 +1,93 @@
+# Не удаётся получить доступ к части API из методических материалов
+
+## Вопрос
+Во время занятия некоторые API из методических материалов не открываются (таймауты, 403/429, блокировки в школьной сети), из-за чего демонстрация работы с API срывается.
+
+## Причина
+- Часть сервисов может быть ограничена по региону или провайдеру.
+- Бесплатные API часто имеют нестабильную доступность или лимиты.
+- Школьные/корпоративные сети иногда блокируют отдельные домены.
+
+## Решение
+Для демонстрации базовых GET-запросов используйте публичные API без ключей и VPN.
+
+### Рекомендуемые публичные API (GET, без ключей)
+1. JSONPlaceholder — `https://jsonplaceholder.typicode.com/posts/1`
+2. Cat Fact — `https://catfact.ninja/fact`
+3. Official Joke API — `https://official-joke-api.appspot.com/random_joke`
+4. Quotable — `https://api.quotable.io/random`
+5. Agify — `https://api.agify.io/?name=alex`
+6. Genderize — `https://api.genderize.io/?name=alex`
+7. Nationalize — `https://api.nationalize.io/?name=alex`
+8. Dog CEO — `https://dog.ceo/api/breeds/image/random`
+9. Universities API — `http://universities.hipolabs.com/search?country=Kazakhstan`
+10. CoinDesk (BTC price) — `https://api.coindesk.com/v1/bpi/currentprice.json`
+
+## Примеры кода (Python + requests)
+
+### 1) Базовый GET + разбор JSON
+```python
+import requests
+
+url = "https://jsonplaceholder.typicode.com/posts/1"
+r = requests.get(url, timeout=10)
+print("Status:", r.status_code)
+print(r.json())
+```
+
+### 2) Параметры запроса (params)
+```python
+import requests
+
+url = "https://api.agify.io/"
+params = {"name": "alex"}
+r = requests.get(url, params=params, timeout=10)
+print(r.url)          # итоговый URL с query params
+print(r.json())
+```
+
+### 3) Безопасная обработка ошибок
+```python
+import requests
+
+try:
+    r = requests.get("https://catfact.ninja/fact", timeout=10)
+    r.raise_for_status()
+    data = r.json()
+    print("Факт:", data.get("fact"))
+except requests.exceptions.Timeout:
+    print("Превышено время ожидания")
+except requests.exceptions.HTTPError as e:
+    print("HTTP ошибка:", e)
+except requests.exceptions.RequestException as e:
+    print("Ошибка сети:", e)
+```
+
+### 4) Единый шаблон для урока (можно менять URL)
+```python
+import requests
+
+API_URLS = [
+    "https://official-joke-api.appspot.com/random_joke",
+    "https://dog.ceo/api/breeds/image/random",
+    "https://api.quotable.io/random",
+]
+
+for url in API_URLS:
+    try:
+        r = requests.get(url, timeout=10)
+        r.raise_for_status()
+        print(f"\n=== {url} ===")
+        print(r.json())
+    except requests.RequestException as e:
+        print(f"\n=== {url} ===")
+        print("Ошибка:", e)
+```
+
+## Примечания
+- Перед уроком откройте 2–3 API в браузере и убедитесь, что они отвечают.
+- Держите минимум 3 резервных API, чтобы быстро переключиться при блокировке.
+- Для школьных занятий лучше использовать короткие JSON-ответы (легче объяснять структуру данных).
+
+## Обсуждение
+- GitHub Issue: [Не удаётся получить доступ к части API из методических материалов](https://github.com/ErnestMatskevich/kb-knowledge/issues?q=is%3Aissue+%22%D0%9D%D0%B5+%D1%83%D0%B4%D0%B0%D1%91%D1%82%D1%81%D1%8F+%D0%BF%D0%BE%D0%BB%D1%83%D1%87%D0%B8%D1%82%D1%8C+%D0%B4%D0%BE%D1%81%D1%82%D1%83%D0%BF+%D0%BA+%D1%87%D0%B0%D1%81%D1%82%D0%B8+API+%D0%B8%D0%B7+%D0%BC%D0%B5%D1%82%D0%BE%D0%B4%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%B8%D1%85+%D0%BC%D0%B0%D1%82%D0%B5%D1%80%D0%B8%D0%B0%D0%BB%D0%BE%D0%B2%22)


### PR DESCRIPTION
### Motivation
- Automate keeping the repository-based `wiki-src` folder and the GitHub Pages wiki in sync to avoid manual copy-and-paste. 
- Provide a Russian guidance note for instructors about unreliable or blocked public APIs used in lessons so demos have reliable fallbacks.

### Description
- Add `import-wiki.yml` workflow that can be manually triggered (`workflow_dispatch`) to clone the repo `.wiki` remote, copy `.md` files into `wiki-src`, and commit them to `main`.
- Add `wiki-sync.yml` workflow that runs on `push` to `main` when files under `wiki-src/**/*.md` change; it detects added/modified files, clones the `.wiki` repo, copies markdown into it, and commits/pushes the wiki changes.
- Add a new Russian markdown file `wiki-src/Не удаётся получить доступ к API.md` with explanations, recommended public APIs, and example code snippets for lesson fallback scenarios.
- Workflows set appropriate repository permissions and configure commit authoring as `github-actions` when pushing changes.

### Testing
- No automated tests were run for these changes; the workflows will execute on GitHub Actions when triggered or when `wiki-src` files are pushed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a24cc2b66483289a618ec6551da25d)